### PR TITLE
Fix settings window renderer crash from undefined logger

### DIFF
--- a/src/ui/settings-window.js
+++ b/src/ui/settings-window.js
@@ -1,4 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {    
+    const logger = {
+        info: (...args) => console.log('[SettingsWindowUI]', ...args)
+    };
+
     // Get DOM elements
     const closeButton = document.getElementById('closeButton');
     const quitButton = document.getElementById('quitButton');


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` in the settings renderer when icon image handlers call `logger.info(...)` while `logger` was not defined.

### Description
- Add a minimal renderer-local `logger` shim at the top of `src/ui/settings-window.js` that implements `info` via `console.log` so existing `logger.info` calls do not crash the page and logging behavior is preserved.

### Testing
- Ran `node --check src/ui/settings-window.js` and a bulk syntax check `for f in *.js src/**/*.js lib/**/*.js; do [ -f "$f" ] && node --check "$f" || true; done`, both of which passed; and
- Attempted `npm run build -- --dir` which failed due to Electron binary download returning `403 Forbidden`, which is an external environment issue unrelated to this code change.

