### PR TITLE
guard app.setName in setupStealth to prevent crash

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,9 @@ class ApplicationController {
     }
 
     // Set default stealth app name early
-    app.setName("Terminal "); // Default to Terminal stealth mode
+    if (app && typeof app.setName === 'function') {
+      app.setName("Terminal ");
+    }
     process.title = "Terminal ";
 
     if (


### PR DESCRIPTION
## Summary
- added a null check around `app.setName()` in `setupStealth()` 
- when `ELECTRON_RUN_AS_NODE` is set in the environment, the electron `app` module is not available and `app.setName()` throws, crashing the whole process before it even reaches `app.whenReady()`
- this just wraps it in a safety check so it fails silently, the same call in `onAppReady()` still sets the name once the app is actually ready

## How to reproduce
1. set `ELECTRON_RUN_AS_NODE=1` in your shell (some tools like VS Code extensions do this)
2. run `npm start`
3. app crashes with `TypeError: Cannot read properties of undefined (reading 'setName')`

## Test plan
- [x] verified app launches normally on windows after the fix
- [x] stealth name still gets set correctly via the existing `app.setName` call in `onAppReady()`